### PR TITLE
Use America/Los_Angeles instead of PST8PDT

### DIFF
--- a/lib/DateTimeX/Easy.pm
+++ b/lib/DateTimeX/Easy.pm
@@ -167,7 +167,7 @@ You can pass the following in:
 
     soft_time_zone_conversion   # Set this flag to 1 if you don't want the time to change when a given timezone is
                                 # different from a parsed timezone. For example, "10:00 UTC" soft converted to
-                                # PST8PDT would be "10:00 PST8PDT".
+                                # America/Los_Angeles would be "10:00 America/Los_Angeles".
 
     time_zone_if_floating       # The value of this option should be a valid timezone. If this option is set, then a DateTime object
                                 # with a floating timezone has it's timezone set to the value.
@@ -211,10 +211,10 @@ Timezone processing can be a little complicated.  Here are some examples:
 
     DateTimeX::Easy->parse($dt, time_zone => "US/Pacific", soft_time_zone_conversion => 1);
                                                             # Will use US/Pacific as the timezone with NO conversion
-                                                            # For example, "22:00 US/Eastern" will become "22:00 PST8PDT"
+                                                            # For example, "22:00 US/Eastern" will become "22:00 America/Los_Angeles"
 
     DateTimeX::Easy->parse($dt)->set_time_zone("US/Pacific"); # Will use US/Pacific as the timezone WITH conversion
-                                                              # For example, "22:00 US/Eastern" will become "19:00 PST8PDT"
+                                                              # For example, "22:00 US/Eastern" will become "19:00 America/Los_Angeles"
 
     DateTimeX::Easy->parse($dt, time_zone => "US/Pacific"); # Will ALSO use US/Pacific as the timezone WITH conversion
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -176,16 +176,16 @@ TODO: {
     is("$eg", "2007-07-01T22:32:10");
 
     # FIXED
-    $eg = DateTimeX::Easy->parse($dt, time_zone => "PST8PDT", soft_time_zone_conversion => 1); # Will use "US/Pacific" as the timezone with *no* conversion
-    is($eg->time_zone->name, "PST8PDT");
+    $eg = DateTimeX::Easy->parse($dt, time_zone => "America/Los_Angeles", soft_time_zone_conversion => 1); # Will use "US/Pacific" as the timezone with *no* conversion
+    is($eg->time_zone->name, "America/Los_Angeles");
     is("$eg", "2007-07-01T22:32:10");
 
-    $eg = DateTimeX::Easy->parse($dt)->set_time_zone("PST8PDT"); # Will use "US/Pacific" as the timezone WITH conversion
-    is($eg->time_zone->name, "PST8PDT");
+    $eg = DateTimeX::Easy->parse($dt)->set_time_zone("America/Los_Angeles"); # Will use "US/Pacific" as the timezone WITH conversion
+    is($eg->time_zone->name, "America/Los_Angeles");
     is("$eg", "2007-07-01T19:32:10");
 
-    $eg = DateTimeX::Easy->parse($dt, time_zone => "PST8PDT"); # Will ALSO use "US/Pacific" as the timezone WITH conversion
-    is($eg->time_zone->name, "PST8PDT");
+    $eg = DateTimeX::Easy->parse($dt, time_zone => "America/Los_Angeles"); # Will ALSO use "US/Pacific" as the timezone WITH conversion
+    is($eg->time_zone->name, "America/Los_Angeles");
     is("$eg", "2007-07-01T19:32:10");
 
     $eg = DateTimeX::Easy->parse($dt, time_zone => "floating");


### PR DESCRIPTION
tzdata-2024b added "PST8PDT" alias for "America/Los_Angeles" time zone into "backward" file. This change was inherited to DateTime-TimeZone-2.63:

    $ perl -MDateTime::TimeZone -e 'print DateTime::TimeZone->new(name=>q{PST8PDT})->name, qq{\n}'
    America/Los_Angeles

As a result, t/01-basic.t started to fail on tests expecting "PST8PDT" zone:

    #   Failed test at t/01-basic.t line 180.
    #          got: 'America/Los_Angeles'
    #     expected: 'PST8PDT'
    #   Failed test at t/01-basic.t line 184.
    #          got: 'America/Los_Angeles'
    #     expected: 'PST8PDT'
    #   Failed test at t/01-basic.t line 188.
    #          got: 'America/Los_Angeles'
    #     expected: 'PST8PDT'
    # Looks like you failed 3 tests of 76.
    t/01-basic.t .....
    Dubious, test returned 3 (wstat 768, 0x300)
    Failed 3/76 subtests

This patch fixes the failures by using "America/Los_Angeles" to avoid using identifiers which have changed to an alias.